### PR TITLE
Switch to using hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ This pdm plugin can be installed with the command:
 `pdm plugin add pdm-buildlocked`
 
 ## Usage
-This plugin modifies the built in `pdm build` command to include the `--locked` argument. 
-When specified the resulting artifacts will have all their dependencies (including 
-transitive ones) pinned to the versions specified in the lock file.
+Locked build mode can be enabled by including the following in your `pyproject.toml`
+file. When enabled, running `pdm build` or `pdm publish` will cause the resulting 
+distribution will have all dependencies (including transitive ones) pinned to the 
+versions specified in the lock file.
 
-`pdm build --locked`
+```toml
+[tool.pdm.build]
+buildlocked = true
+```

--- a/build_locked.py
+++ b/build_locked.py
@@ -1,56 +1,56 @@
-import argparse
+import atexit
 from copy import deepcopy
 
 from pdm.cli.actions import resolve_candidates_from_lockfile
 from pdm.project import Project
-from pdm.cli.commands.build import Command as BaseBuildCommand
+from pdm.signals import pre_build, post_build
 
 
-class BuildLockedCommand(BaseBuildCommand):
-    """Build artifacts for distribution"""
+class BuildLocker:
+    def __init__(self):
+        self.project = None
+        self.orig_pyproject = None
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
-        super().add_arguments(parser)
-        parser.add_argument(
-            "--locked",
-            dest="locked",
-            default=False,
-            action="store_true",
-            help="Build with all dependencies (including transitive) locked "
-                 "to their versions from the lock file",
-        )
+    def lock(self, project: Project, **kwargs):
+        enabled = project.tool_settings.get("build", {}).get("buildlocked")
+        if not enabled:
+            return
+        project.core.ui.echo("Locking dependencies before building...")
+        self.project = project
+        self.orig_pyproject = deepcopy(project.pyproject)
 
-    def handle(self, project: Project, options: argparse.Namespace) -> None:
-        """The command handler function.
-        :param project: the pdm project instance
-        :param options: the parsed Namespace object
-        """
-        if not options.locked:
-            return super().handle(project, options)
-        orig_pyproject = deepcopy(project.pyproject)
-        try:
-            requirements = project.get_dependencies("default")
+        requirements = project.get_dependencies("default")
+        candidates = resolve_candidates_from_lockfile(
+            project, requirements.values()
+        ).values()
+        project.meta["dependencies"] = [
+            str(c.req.as_pinned_version(c.version)) for c in candidates
+        ]
+        optional_groups = project.meta.get("optional-dependencies", {}).keys()
+        for group in optional_groups:
+            requirements = project.get_dependencies(group)
             candidates = resolve_candidates_from_lockfile(
                 project, requirements.values()
             ).values()
-            project.meta["dependencies"] = [
+            project.meta.setdefault("optional-dependencies", {})[group] = [
                 str(c.req.as_pinned_version(c.version)) for c in candidates
             ]
-            optional_groups = project.meta.get("optional-dependencies", {}).keys()
-            for group in optional_groups:
-                requirements = project.get_dependencies(group)
-                candidates = resolve_candidates_from_lockfile(
-                    project, requirements.values()
-                ).values()
-                project.meta.setdefault("optional-dependencies", {})[group] = [
-                    str(c.req.as_pinned_version(c.version)) for c in candidates
-                ]
-            project.write_pyproject()
-            return super().handle(project, options)
-        finally:
-            project.pyproject = orig_pyproject
-            project.write_pyproject()
+        project.write_pyproject()
+
+    def unlock(self, *args, **kwargs):
+        if self.project and self.orig_pyproject:
+            self.project.core.ui.echo("Restoring dependencies after build...")
+            self.project.pyproject = self.orig_pyproject
+            self.project.write_pyproject()
+            self.project = None
+            self.orig_pyproject = None
 
 
 def register(core):
-    core.register_command(BuildLockedCommand, "build")
+    locker = BuildLocker()
+    pre_build.connect(locker.lock)
+    post_build.connect(locker.unlock)
+    # In case something went wrong during build and post_build doesn't fire,
+    # make sure we still restore the pyproject file. This also holds a reference
+    # to 'locker', and makes sure it isn't garbage collected.
+    atexit.register(locker.unlock)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-buildlocked"
-version = "0.1.0a1"
+version = "0.1.1a1"
 description = "Adds the ability to build the project using locked dependencies."
 authors = [
     {name = "Chase Sterling", email = "chase.sterling@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdm-buildlocked"
-version = "0.1.1a1"
+version = "0.2.0a1"
 description = "Adds the ability to build the project using locked dependencies."
 authors = [
     {name = "Chase Sterling", email = "chase.sterling@gmail.com"},


### PR DESCRIPTION
This switches to using pre and post-build hooks, which makes us compatible with building during the publish command as well. Since it isn't a CLI command anymore, it moves the flag to enable to be in pyproject.toml. I think this makes more sense as well, because a given project would probably always release locked builds, and not a mix of locked and unlocked.

Currently the option is under tool.pdm.build, however I'm not sure if I should put it directly in the pdm namespace like that. Also, should it change to just 'locked' or 'locked_deps' if it's under the pdm.build key?
```toml
[tool.pdm.build]
buildlocked = true
```

Questions:
- [ ] What key in pyproject should this be under?
- [ ] Seem like a good change?