### PR TITLE
Update pyproject file write

### DIFF
--- a/build_locked.py
+++ b/build_locked.py
@@ -35,13 +35,13 @@ class BuildLocker:
             project.meta.setdefault("optional-dependencies", {})[group] = [
                 str(c.req.as_pinned_version(c.version)) for c in candidates
             ]
-        project.write_pyproject()
+        project.pyproject.write()
 
     def unlock(self, *args, **kwargs):
         if self.project and self.orig_pyproject:
             self.project.core.ui.echo("Restoring dependencies after build...")
             self.project.pyproject = self.orig_pyproject
-            self.project.write_pyproject()
+            self.project.pyproject.write()
             self.project = None
             self.orig_pyproject = None
 


### PR DESCRIPTION
Apparently, the internal API for reading and writing pyproject files has changed on https://github.com/pdm-project/pdm/pull/1499. This requires replacing the `project.write_pyproject` method with `project.pyproject.write()`. 😃 